### PR TITLE
Further OpenCL kernel improvements

### DIFF
--- a/gpu_cl.go
+++ b/gpu_cl.go
@@ -199,9 +199,9 @@ typedef struct __blake2b_state
 {
 	ulong h[8];
 	ulong t[BLAKE2B_LONG_MESSAGE];
-	ulong f[2];
-	uchar  buf[2 * BLAKE2B_BLOCKBYTES];
-	size_t   buflen;
+	ulong f[1];
+	uchar  buf[2 *  BLAKE2B_BLOCKBYTES];
+	ushort buflen;
 } blake2b_state;
 
 enum Blake2b_IV
@@ -215,25 +215,8 @@ enum Blake2b_IV
 	iv6 = 0x1f83d9abfb41bd6bUL,
 	iv7 = 0x5be0cd19137e2179UL,
 };
-__constant const static ulong blake2b_IV[8] = {iv0, iv1, iv2, iv3, iv4, iv5, iv6, iv7};
 
-__constant const static uchar blake2b_sigma[12 * 16] =
-{
-    0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-   14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3,
-   11,  8, 12,  0,  5,  2, 15, 13, 10, 14,  3,  6,  7,  1,  9,  4,
-    7,  9,  3,  1, 13, 12, 11, 14,  2,  6,  5, 10,  4,  0, 15,  8,
-    9,  0,  5,  7,  2,  4, 10, 15, 14,  1, 11, 12,  6,  8,  3, 13,
-    2, 12,  6, 10,  0, 11,  8,  3,  4, 13,  7,  5, 15, 14,  1,  9,
-   12,  5,  1, 15, 14, 13,  4, 10,  0,  7,  6,  3,  9,  2,  8, 11,
-   13, 11,  7, 14, 12,  1,  3,  9,  5,  0, 15,  4,  8,  6,  2, 10,
-    6, 15, 14,  9, 11,  3,  0,  8, 12,  2, 13,  7,  1,  4, 10,  5,
-   10,  2,  8,  4,  7,  6,  1,  5, 15, 11,  9, 14,  3, 12, 13 , 0,
-    0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-   14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3,
-};
-
-static inline int blake2b_increment_counter( blake2b_state *S, const ulong inc )
+static inline int blake2b_increment_counter( blake2b_state *S, const ushort inc )
 {
   S->t[0] += inc;
 #if BLAKE2B_LONG_MESSAGE > 1
@@ -258,18 +241,7 @@ static inline ulong load64( const void *src )
   return w;
 #endif
 }
-static inline void store32( void *dst, uint w )
-{
-#if defined(__ENDIAN_LITTLE__)
-  *( uint * )( dst ) = w;
-#else
-  uchar *p = ( uchar * )dst;
-  *p++ = ( uchar )w; w >>= 8;
-  *p++ = ( uchar )w; w >>= 8;
-  *p++ = ( uchar )w; w >>= 8;
-  *p++ = ( uchar )w;
-#endif
-}
+
 static inline void store64( void *dst, ulong w )
 {
 #if defined(__ENDIAN_LITTLE__)
@@ -287,118 +259,122 @@ static inline void store64( void *dst, ulong w )
 #endif
 }
 
-static inline ulong rotr64(ulong a, ulong shift) { return rotate(a, 64 - shift); }
+static inline void memzero_u32(uint *dest, size_t count)
+{
+  for (ushort i = 0; i < count / sizeof(uint); ++i)
+    dest[i] = 0;
+}
 
-static void memzero (void * dest_a, size_t count)
-{
-	uchar * dest = (uchar *)dest_a;
-	for (size_t i = 0; i < count; ++i)
-	{
-		*dest++ = 0;
-	}
-}
-/* init xors IV with input parameter block */
-static inline int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
-{
-  uchar *p, *h;
-  __constant uchar *v;
-  v = ( __constant uchar * )( blake2b_IV );
-  h = ( uchar * )( S->h );
-  p = ( uchar * )( P );
-  /* IV XOR ParamBlock */
-  memzero( S, sizeof( blake2b_state ) );
-  for( int i = 0; i < BLAKE2B_OUTBYTES; ++i ) h[i] = v[i] ^ p[i];
-  return 0;
-}
-static inline int blake2b_init( blake2b_state *S, const uchar outlen )
+static void blake2b_init( blake2b_state *S, const uchar outlen )
 {
   blake2b_param P[1];
-  if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
   P->digest_length = outlen;
   P->key_length    = 0;
   P->fanout        = 1;
   P->depth         = 1;
-  store32( &P->leaf_length, 0 );
-  store64( &P->node_offset, 0 );
-  P->node_depth    = 0;
-  P->inner_length  = 0;
-  memzero( P->reserved, sizeof( P->reserved ) );
-  memzero( P->salt,     sizeof( P->salt ) );
-  memzero( P->personal, sizeof( P->personal ) );
-  return blake2b_init_param( S, P );
+  P->leaf_length   = 0;
+
+  /* init XORs IV with input parameter block */
+  ulong *p = ( ulong * ) P;
+  S->h[0] = iv0 ^ p[0];
+  S->h[1] = iv1;
+  S->h[2] = iv2; S->h[3] = iv3;
+  S->h[4] = iv4; S->h[5] = iv5;
+  S->h[6] = iv6; S->h[7] = iv7;
+  memzero_u32( (uchar *) S + sizeof(S->h), sizeof(blake2b_state) - sizeof(S->h) );
 }
 
-#define G(r,i,a,b,c,d) \
-  do { \
-        a = a + b + m[blake2b_sigma[r * 16 + i * 2 + 0]]; \
-        d = rotr64(d ^ a, 32); \
-        c = c + d; \
-        b = rotr64(b ^ c, 24); \
-        a = a + b + m[blake2b_sigma[r * 16 + i * 2 + 1]]; \
-        d = rotr64(d ^ a, 16); \
-        c = c + d; \
-        b = rotr64(b ^ c, 63); \
-  } while(0)
-#define ROUND(r)  \
-  do { \
-        G(r,0,v[ 0],v[ 4],v[ 8],v[12]); \
-        G(r,1,v[ 1],v[ 5],v[ 9],v[13]); \
-        G(r,2,v[ 2],v[ 6],v[10],v[14]); \
-        G(r,3,v[ 3],v[ 7],v[11],v[15]); \
-        G(r,4,v[ 0],v[ 5],v[10],v[15]); \
-        G(r,5,v[ 1],v[ 6],v[11],v[12]); \
-        G(r,6,v[ 2],v[ 7],v[ 8],v[13]); \
-        G(r,7,v[ 3],v[ 4],v[ 9],v[14]); \
-  } while(0)
-#define BLAKE2B_ROUNDS() ROUND(0);ROUND(1);ROUND(2);ROUND(3);ROUND(4);ROUND(5);ROUND(6);ROUND(7);ROUND(8);ROUND(9);ROUND(10);ROUND(11);
+static inline ulong rotr64(ulong a, ulong shift) { return rotate(a, 64 - shift); }
 
-static int blake2b_compress( blake2b_state *S, __private const uchar block[BLAKE2B_BLOCKBYTES] )
+#define G32(s, vva, vb1, vb2, vvc, vd1, vd2)                      \
+  do {                                                            \
+    vva += (ulong2) (vb1 + m[s >> 24], vb2 + m[(s >> 8) & 0xf]);  \
+    vd1 = rotr64(vd1 ^ vva.s0, 32lu);                             \
+    vd2 = rotr64(vd2 ^ vva.s1, 32lu);                             \
+    vvc += (ulong2) (vd1, vd2);                                   \
+    vb1 = rotr64(vb1 ^ vvc.s0, 24lu);                             \
+    vb2 = rotr64(vb2 ^ vvc.s1, 24lu);                             \
+    vva += (ulong2) (vb1 + m[(s >> 16) & 0xf], vb2 + m[s & 0xf]); \
+    vd1 = rotr64(vd1 ^ vva.s0, 16lu);                             \
+    vd2 = rotr64(vd2 ^ vva.s1, 16lu);                             \
+    vvc += (ulong2) (vd1, vd2);                                   \
+    vb1 = rotr64(vb1 ^ vvc.s0, 63lu);                             \
+    vb2 = rotr64(vb2 ^ vvc.s1, 63lu);                             \
+  } while (0)
+
+#define G2v(s, a, b, c, d) \
+  G32(s, vv[a/2], vv[b/2].s0, vv[b/2].s1, vv[c/2], vv[d/2].s0, vv[d/2].s1)
+
+#define G2vsplit(s, a, vb1, vb2, c, vd1, vd2) \
+  G32(s, vv[a/2], vb1, vb2, vv[c/2], vd1, vd2)
+
+#define ROUND(sig0, sig1, sig2, sig3)                                        \
+  do {                                                                       \
+    G2v     (sig0, 0, 4,  8, 12);                                            \
+    G2v     (sig1, 2, 6, 10, 14);                                            \
+    G2vsplit(sig2, 0, vv[5/2].s1, vv[6/2].s0, 10, vv[15/2].s1, vv[12/2].s0); \
+    G2vsplit(sig3, 2, vv[7/2].s1, vv[4/2].s0,  8, vv[13/2].s1, vv[14/2].s0); \
+  } while(0)
+
+static void blake2b_compress( blake2b_state *S )
 {
   ulong m[16];
-  ulong v[16];
   int i;
 
-  for( i = 0; i < 16; ++i )
-        m[i] = load64( block + i * sizeof( m[i] ) );
+  #pragma unroll 16
+  for (i = 0; i < 16; i++)
+      m[i] = load64(S->buf + i * sizeof(m[0]));
 
-  #pragma unroll 8
-  for( i = 0; i < 8; ++i )
-        v[i] = S->h[i];
-
-  v[ 8] = iv0;
-  v[ 9] = iv1;
-  v[10] = iv2;
-  v[11] = iv3;
-  v[12] = S->t[0] ^ iv4;
+  ulong2 vv[8] = {
+    { S->h[0], S->h[1] },
+    { S->h[2], S->h[3] },
+    { S->h[4], S->h[5] },
+    { S->h[6], S->h[7] },
+    { iv0, iv1 },
+    { iv2, iv3 },
+    { iv4 ^ S->t[0],
 #if BLAKE2B_LONG_MESSAGE > 1
-  v[13] = S->t[1] ^ iv5;
+      iv5 ^ S->t[1] },
 #else
-  v[13] = iv5;
+      iv5 },
 #endif
-  v[14] = S->f[0] ^ iv6;
-  v[15] = iv7; /* ^ S->f[1] removed: no last_node */
+    { iv6 ^ S->f[0],
+      iv7 /* ^ S->f[1] is removed because no last_node */ },
+  };
 
-  BLAKE2B_ROUNDS();
+  ROUND(0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f);
+  ROUND(0x0e0a0408, 0x090f0d06, 0x010c0002, 0x0b070503);
+  ROUND(0x0b080c00, 0x05020f0d, 0x0a0e0306, 0x07010904);
+  ROUND(0x07090301, 0x0d0c0b0e, 0x0206050a, 0x04000f08);
+  ROUND(0x09000507, 0x02040a0f, 0x0e010b0c, 0x0608030d);
+  ROUND(0x020c060a, 0x000b0803, 0x040d0705, 0x0f0e0109);
+  ROUND(0x0c05010f, 0x0e0d040a, 0x00070603, 0x0902080b);
+  ROUND(0x0d0b070e, 0x0c010309, 0x05000f04, 0x0806020a);
+  ROUND(0x060f0e09, 0x0b030008, 0x0c020d07, 0x01040a05);
+  ROUND(0x0a020804, 0x07060105, 0x0f0b090e, 0x030c0d00);
+  ROUND(0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f);
+  ROUND(0x0e0a0408, 0x090f0d06, 0x010c0002, 0x0b070503);
 
-  #pragma unroll 8
-  for( i = 0; i < 8; ++i )
-        S->h[i] ^= v[i] ^ v[i + 8];
-
-  return 0;
+  #pragma unroll 4
+  for (i = 0; i < 4; ++i) {
+      ulong2 x = vv[i] ^ vv[i + 4];
+      S->h[i*2  ] ^= x.s0;
+      S->h[i*2+1] ^= x.s1;
+  }
 }
-#undef G
+#undef G32
+#undef G2v
+#undef G2vsplit
 #undef ROUND
-#undef BLAKE2B_ROUNDS
 
-static void ucharcpy (uchar * dst, uchar const * src, size_t count)
+static inline void memcpy_u64(ulong *dst, ulong const *src, ushort count)
 {
-	for (size_t i = 0; i < count; ++i)
-	{
-		*dst++ = *src++;
-	}
+    for (ushort i = 0; i < count / sizeof(ulong); i++)
+        *dst++ = *src++;
 }
+
 /* inlen now in bytes */
-static int blake2b_update( blake2b_state *S, const uchar *in, ulong inlen )
+static void blake2b_update( blake2b_state *S, const uchar *in, ushort inlen )
 {
   while( inlen > 0 )
   {
@@ -406,69 +382,47 @@ static int blake2b_update( blake2b_state *S, const uchar *in, ulong inlen )
 	size_t fill = 2 * BLAKE2B_BLOCKBYTES - left;
 	if( inlen > fill )
 	{
-	  ucharcpy( S->buf + left, in, fill ); // Fill buffer
+	  memcpy_u64( S->buf + left, in, fill ); // Fill buffer
 	  S->buflen += fill;
 	  blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
-	  blake2b_compress( S, S->buf ); // Compress
-	  ucharcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES ); // Shift buffer left
+	  blake2b_compress( S );
 	  S->buflen -= BLAKE2B_BLOCKBYTES;
 	  in += fill;
 	  inlen -= fill;
 	}
 	else // inlen <= fill
 	{
-	  ucharcpy( S->buf + left, in, inlen );
+	  memcpy_u64( S->buf + left, in, inlen );
 	  S->buflen += inlen; // Be lazy, do not compress
-	  in += inlen;
-	  inlen -= inlen;
+	  break;
 	}
   }
-  return 0;
 }
-/* Is this correct? */
-static int blake2b_final( blake2b_state *S, uchar *out, uchar outlen )
-{
-  uchar buffer[BLAKE2B_OUTBYTES];
-  if( S->buflen > BLAKE2B_BLOCKBYTES )
-  {
-	blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
-	blake2b_compress( S, S->buf );
-	S->buflen -= BLAKE2B_BLOCKBYTES;
-	ucharcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, S->buflen );
-  }
-  //blake2b_increment_counter( S, S->buflen );
-  ulong inc = (ulong)S->buflen;
-  S->t[0] += inc;
-//  if ( S->t[0] < inc )
-//    S->t[1] += 1;
-  // This seems to crash the opencl compiler though fortunately this is calculating size and we don't do things bigger than 2^32
 
-  // blake2b_set_lastblock(S)
-  S->f[0] = ~0UL;
-  memzero( S->buf + S->buflen, 2 * BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
-  blake2b_compress( S, S->buf );
-
-  #pragma unroll 8
-  for( int i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
-	store64( buffer + sizeof( S->h[i] ) * i, S->h[i] );
-  ucharcpy( out, buffer, outlen );
-  return 0;
-}
-static void ucharcpyglb (uchar * dst, __global uchar const * src, size_t count)
+static void blake2b_final( blake2b_state *S, uchar *out, ushort outlen )
 {
-	for (size_t i = 0; i < count; i++)
-	{
-		*dst = *src;
-		++dst;
-		++src;
-	}
+  blake2b_increment_counter( S, S->buflen );
+
+  S->f[0] = ~0UL; // set last block
+  blake2b_compress( S );
+
+  // assume outlen is multiple of sizeof(ulong)
+  for( int i = 0; i < outlen/sizeof(ulong); ++i )
+      store64( out + sizeof(S->h[0]) * i, S->h[i] );
 }
-	
+
+static inline void memcpy_u64_global(ulong *dst, __global ulong const *src, ushort count)
+{
+    #pragma unroll 4
+    for (ushort i = 0; i < count / sizeof(ulong); i++)
+        *dst++ = *src++;
+}
+
 __kernel void nano_work (__global ulong const * attempt, __global ulong * result_a, __global uchar const * item_a, __global ulong const * difficulty_a, __global ulong * result_hash_a)
 {
 	int const thread = get_global_id (0);
 	uchar item_l [32];
-	ucharcpyglb (item_l, item_a, 32);
+	memcpy_u64_global(item_l, item_a, 32);
 	ulong attempt_l = *attempt + thread;
 	blake2b_state state;
 	blake2b_init (&state, sizeof (ulong));


### PR DESCRIPTION
This patch improves OpenCL kernel in the following aspects:
1. Shrink blake2b_state structure;
2. Eliminate the cost of table look-up;
3. Explict data access for efficiency;
4. Avoid unnecessary initializations;