### PR TITLE
fix: Avoid getting trash value from kernel program

### DIFF
--- a/gpu_cl.go
+++ b/gpu_cl.go
@@ -79,6 +79,14 @@ func (w *clWorker) GenerateWork(ctx *Context, root []byte, difficulty uint64) (e
 				return err
 			}
 
+			if err = w.queue.EnqueueWriteBuffer(w.ResultBuffer.Buffer, false, w.ResultBuffer.size, unsafe.Pointer(&result)); err != nil {
+				return err
+			}
+
+			if err = w.queue.EnqueueWriteBuffer(w.ResultHashBuffer.Buffer, false, w.ResultHashBuffer.size, unsafe.Pointer(&resulthash[0])); err != nil {
+				return err
+			}
+
 			if err = w.queue.EnqueueNDRangeKernel(w.kernel, 1, []uint64{w.thread}); err != nil {
 				return err
 			}


### PR DESCRIPTION
The EnqueueWriteBuffer() makes sure the later EnqueueReadBuffer() would
not get the trash value from the kernel program.
Otherwise, the PoW validation would fail.

The trash value bug happens when using AMD GPU with ROCm driver.